### PR TITLE
Change numeric validation to accept num instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+- Change numeric validation to accept num instead of int.
+
 # 1.0.3
 
 - Fix nested `MutliValidator`.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.3"
+    version: "1.0.4"
   form_field_validator:
     dependency: transitive
     description:

--- a/lib/flutter_validation.dart
+++ b/lib/flutter_validation.dart
@@ -76,7 +76,7 @@ class Validator {
           errorText:
               ValidationLocalizations.of(_context)!.tooLong(attribute, count));
 
-  MultiValidator lessThan(String attribute, int count) => MultiValidator([
+  MultiValidator lessThan(String attribute, num count) => MultiValidator([
         isNum(attribute),
         ExpressionValidator(
           (String? value) => num.parse(value!) < count,
@@ -85,7 +85,7 @@ class Validator {
         )
       ]);
 
-  MultiValidator lessThanOrEqualTo(String attribute, int count) =>
+  MultiValidator lessThanOrEqualTo(String attribute, num count) =>
       MultiValidator([
         isNum(attribute),
         ExpressionValidator(
@@ -95,7 +95,7 @@ class Validator {
         )
       ]);
 
-  MultiValidator greaterThan(String attribute, int count) => MultiValidator([
+  MultiValidator greaterThan(String attribute, num count) => MultiValidator([
         isNum(attribute),
         ExpressionValidator(
           (String? value) => num.parse(value!) > count,
@@ -104,7 +104,7 @@ class Validator {
         ),
       ]);
 
-  MultiValidator greaterThanOrEqualTo(String attribute, int count) =>
+  MultiValidator greaterThanOrEqualTo(String attribute, num count) =>
       MultiValidator([
         isNum(attribute),
         ExpressionValidator((String? value) => num.parse(value!) >= count,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_validation
 description: Ready localized validation messages.
-version: 1.0.3
+version: 1.0.4
 author: hsul4n
 homepage: https://github.com/hsul4n/flutter_validation
 


### PR DESCRIPTION
I've added support for using `num` instead of `int`.